### PR TITLE
fix: upgrade express to 4.17.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -301,7 +301,7 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "express": {
-      "version": "4.17.1",
+      "version": "4.17.3",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
       "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
       "requires": {


### PR DESCRIPTION

# Harness SAST and SCA AutoFix

This PR was created automatically by the Harness SAST and SCA AutoFix tool.


Some manual intervention might be required before merging this PR.

## Fix for Finding **[193](https://app.stg.shiftleft.io/apps/shiftleft-js-demo/vulnerabilities?appId=shiftleft-js-demo&findingId=193&scan=39)**




### 📝 Description
**Upgrade Version:** `4.17.3`

**Summary:**
This upgrade addresses CVE-2022-24999, a vulnerability in the `qs` library (a dependency of Express) that allows attackers to cause a Node process hang through a specially crafted query string using `__proto__` keys. The vulnerability affects Express 4.17.1, which depends on qs 6.7.0. Upgrading to Express 4.17.3 brings in qs 6.9.7, which includes the backported fix for this vulnerability.

> [!IMPORTANT]
> **Potential Breaking Changes:** This is a patch version upgrade (4.17.1 → 4.17.3), so breaking changes are unlikely. However, please review and test thoroughly before merging.

---

### 🛡️ Security Impact

#### Current version vulnerabilities: 1 (Critical: 0, High: 1, Medium: 0, Low: 0)

| Severity | CVSS Score | Upgrade Version | Reference Identifiers |
| :---: | :--- | :--- | :--- |
| ![high][high-badge] | `7.5` | `4.17.3` | [CVE-2022-24999](https://www.cve.org/CVERecord?id=CVE-2022-24999) |

#### Upgrade version vulnerabilities: 0 (Critical: 0, High: 0, Medium: 0, Low: 0)

[critical-badge]: https://img.shields.io/badge/Critical-d73a4a?style=flat-square
[high-badge]: https://img.shields.io/badge/High-e4a228?style=flat-square
[medium-badge]: https://img.shields.io/badge/Medium-f5c518?style=flat-square
[low-badge]: https://img.shields.io/badge/Low-0075ca?style=flat-square

