### PR TITLE
fix: upgrade follow-redirects to 1.14.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -379,7 +379,7 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.10",
+      "version": "1.14.7",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
       "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {


### PR DESCRIPTION

# Harness SAST and SCA AutoFix

This PR was created automatically by the Harness SAST and SCA AutoFix tool.


Some manual intervention might be required before merging this PR.

## Fix for Finding **[398](https://app.stg.shiftleft.io/apps/shiftleft-js-demo/vulnerabilities?appId=shiftleft-js-demo&findingId=398&scan=3)**




### 📝 Description
**Upgrade Version:** `1.14.7`

**Summary:**
This upgrade addresses CVE-2022-0155, a high-severity vulnerability in the follow-redirects package that could lead to exposure of private personal information to unauthorized actors. Upgrading from version 1.5.10 to 1.14.7 resolves this security issue.

> [!IMPORTANT]
> **Potential Breaking Changes:** This is a minor version upgrade (1.5.10 → 1.14.7) which may include breaking changes given the significant version jump. Please review the changelog and test thoroughly before merging.

---

### 🛡️ Security Impact

#### Current version vulnerabilities: 1 (Critical: 0, High: 1, Medium: 0, Low: 0)

| Severity | CVSS Score | Upgrade Version | Reference Identifiers |
| :---: | :--- | :--- | :--- |
| ![high][high-badge] | `8` | `1.14.7` | [CVE-2022-0155](https://www.cve.org/CVERecord?id=CVE-2022-0155) |

#### Upgrade version vulnerabilities: 0 (Critical: 0, High: 0, Medium: 0, Low: 0)

[critical-badge]: https://img.shields.io/badge/Critical-d73a4a?style=flat-square
[high-badge]: https://img.shields.io/badge/High-e4a228?style=flat-square
[medium-badge]: https://img.shields.io/badge/Medium-f5c518?style=flat-square
[low-badge]: https://img.shields.io/badge/Low-0075ca?style=flat-square

