### PR TITLE
fix: upgrade bson to 1.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -130,8 +130,8 @@
       }
     },
     "bson": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
       "integrity": "sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg=="
     },
     "bytes": {


### PR DESCRIPTION

# Harness SAST and SCA AutoFix

This PR was created automatically by the Harness SAST and SCA AutoFix tool.


Some manual intervention might be required before merging this PR.

## Fix for Finding **[205](https://app.stg.shiftleft.io/apps/shiftleft-js-demo/vulnerabilities?appId=shiftleft-js-demo&findingId=205&scan=4)**




### 📝 Description
**Upgrade Version:** `1.1.4`

**Summary:**
This upgrade addresses CVE-2020-7610, a critical deserialization vulnerability in the bson package. All versions before 1.1.4 are vulnerable to deserialization of untrusted data, where the package incorrectly handles unknown `_bsontype` values, potentially leading to objects being serialized as documents rather than the intended BSON type. Upgrading to version 1.1.4 resolves this security issue.

> [!IMPORTANT]
> **Potential Breaking Changes:** This is a patch version upgrade (1.1.1 → 1.1.4), so breaking changes are unlikely. However, please review and test thoroughly before merging.

---

### 🛡️ Security Impact

#### Current version vulnerabilities: 1 (Critical: 1, High: 0, Medium: 0, Low: 0)

| Severity | CVSS Score | Upgrade Version | Reference Identifiers |
| :---: | :--- | :--- | :--- |
| ![critical][critical-badge] | `9.8` | `1.1.4` | [CVE-2020-7610](https://www.cve.org/CVERecord?id=CVE-2020-7610) |

#### Upgrade version vulnerabilities: 0 (Critical: 0, High: 0, Medium: 0, Low: 0)

[critical-badge]: https://img.shields.io/badge/Critical-d73a4a?style=flat-square
[high-badge]: https://img.shields.io/badge/High-e4a228?style=flat-square
[medium-badge]: https://img.shields.io/badge/Medium-f5c518?style=flat-square
[low-badge]: https://img.shields.io/badge/Low-0075ca?style=flat-square

