### PR TITLE
fix: upgrade lodash to 4.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -521,7 +521,7 @@
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
     },
     "lodash": {
-      "version": "4.17.15",
+      "version": "4.18.0",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },


### PR DESCRIPTION

# Harness SAST and SCA AutoFix

This PR was created automatically by the Harness SAST and SCA AutoFix tool.


Some manual intervention might be required before merging this PR.

## Fix for Finding **[152](https://app.stg.shiftleft.io/apps/shiftleft-js-demo/vulnerabilities?appId=shiftleft-js-demo&findingId=152&scan=2)**




### 📝 Description
**Upgrade Version:** `4.18.0`

**Summary:**
This upgrade addresses CVE-2026-4800, a critical code injection vulnerability in lodash's `_.template` function. The vulnerability allows attackers to execute arbitrary code at template compilation time by injecting malicious expressions through untrusted `options.imports` key names or via prototype pollution. Upgrading to version 4.18.0 applies validation to imports keys and prevents enumeration of inherited properties.

> [!IMPORTANT]
> **Potential Breaking Changes:** This is a minor version upgrade (4.17.15 → 4.18.0), so breaking changes are unlikely. However, please review and test thoroughly before merging, particularly any code using `_.template` with custom imports.

---

### 🛡️ Security Impact

#### Current version vulnerabilities: 1 (Critical: 0, High: 1, Medium: 0, Low: 0)

| Severity | CVSS Score | Upgrade Version | Reference Identifiers |
| :---: | :--- | :--- | :--- |
| ![high][high-badge] | `8.1` | `4.18.0` | [CVE-2026-4800](https://www.cve.org/CVERecord?id=CVE-2026-4800) |

#### Upgrade version vulnerabilities: 0 (Critical: 0, High: 0, Medium: 0, Low: 0)

[critical-badge]: https://img.shields.io/badge/Critical-d73a4a?style=flat-square
[high-badge]: https://img.shields.io/badge/High-e4a228?style=flat-square
[medium-badge]: https://img.shields.io/badge/Medium-f5c518?style=flat-square
[low-badge]: https://img.shields.io/badge/Low-0075ca?style=flat-square

